### PR TITLE
Include server start in gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+
+jdk:
+ - oraclejdk7
+
+notifications:
+  email: false
+
+install:
+ - redis-server > /dev/null 2>&1 &
+ - sudo apt-get install python-pip npm nodejs
+ - sudo pip install virtualenv
+ - virtualenv qabel-drop
+ - source qabel-drop/bin/activate
+ - pip install -r qabel-drop/requirements.txt
+
+script:
+ - travis_wait ./gradlew check

--- a/README.md
+++ b/README.md
@@ -5,3 +5,31 @@ qabel
 =====
 
 Gradle superproject for all Qabel projects.
+
+## requirements
+
+0. redis-server
+
+0. nodejs
+
+0. npm
+
+0. python moduls from qabel-drop/requirements.txt
+
+## building source
+
+0. Make sure you have a working [git client](http://git-scm.com/) installed
+
+0. clone the source
+   ```
+   git clone https://github.com/Qabel/qabel.git
+   cd qabel
+   git submodule init
+   git submodule update
+   ```
+   
+0. build the project
+   ```
+   ./gradlew build
+   ```
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Gradle superproject for all Qabel projects.
 0. npm
 
 0. python moduls from qabel-drop/requirements.txt
+   ```
+   this could for example automaticly be done using python-pip:
+      pip install -r qabel-drop/requirements.txt
+   ```
 
 ## building source
 
@@ -33,3 +37,26 @@ Gradle superproject for all Qabel projects.
    ./gradlew build
    ```
 
+## starting the Servers
+Normaly the drop and storage server should be started automaticaly, but if you would like to start the servers manually you need to do the following steps
+
+0. dropserver
+   ```
+   linux:
+     ./qabel-drop/drop_server.py
+  
+   windows:
+     python ./qabel-drop/drop_server.py
+   ```
+0. storage-server
+   ```
+   cd qabel-storage
+   npm install
+   
+   linux:
+      nodejs app.js
+
+   windows
+      node app.js
+   ```
+   

--- a/build.gradle
+++ b/build.gradle
@@ -7,3 +7,37 @@ repositories {
 
 dependencies {
 }
+
+class ExecWait extends DefaultTask {
+	String command
+	String ready
+	String directory
+
+	@TaskAction
+	def spawnProcess() {
+
+		ProcessBuilder builder = new ProcessBuilder(command.split(' '))
+		builder.redirectErrorStream(true)
+		builder.directory(new File(directory))
+		Process process = builder.start()
+
+		InputStream stdout = process.getInputStream()
+		BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))
+	}
+}
+
+task startDropServer(type: ExecWait) {
+	command './drop_server.py &'
+	ready 'Drop server running.'
+	directory './qabel-drop/'
+}
+
+task startDropStorage(type: ExecWait) {
+	command 'node app.js &'
+	ready 'Storage server running.'
+	directory './qabel-storage/'
+}
+
+test {
+	dependsOn startDropServer, startDropStorage
+}

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,31 @@ task startDropServer(type: ExecWait) {
 	directory './qabel-drop/'
 }
 
+task getNodeModules(type: ExecWait) {
+	command 'npm install'
+	ready 'Storage server modules initialised.'
+	directory './qabel-storage/'
+}
+
+task checkStorage {
+	File dataFolder = new File("./qabel-storage/data/");
+	if( !dataFolder.exists() ) {
+		dataFolder.mkdirs();
+	}
+	File nodeModulesFolder = new File("./qabel-storage/node_modules/");
+	if( !nodeModulesFolder.exists() ) {
+		getNodeModules.execute()
+	}
+}
+
 task startStorageServer(type: ExecWait) {
+	dependsOn checkStorage	
 	command 'node app.js &'
 	ready 'Storage server running.'
 	directory './qabel-storage/'
 }
+
+
 
 test {
 	dependsOn startDropServer, startStorageServer

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ class ExecWait extends DefaultTask {
 	String ready
 	String directory
 	String logname
+	Process process
+	boolean waitfor
 
 	@TaskAction
 	def spawnProcess() {
@@ -20,26 +22,42 @@ class ExecWait extends DefaultTask {
 		ProcessBuilder builder = new ProcessBuilder(command.split(' '))
 		builder.redirectErrorStream(true)
 		builder.directory(new File(directory))
-		builder.redirectOutput(new File("./log/"+logname+".log"));
+		builder.redirectOutput(new File("./log/"+logname+".log"))
 
-		Process process = builder.start()
+		process = builder.start()
 
 		InputStream stdout = process.getInputStream()
 		BufferedReader reader = new BufferedReader(new InputStreamReader(stdout))
+
+		if(process != null && waitfor==true)
+			process.waitFor()
 	}
 }
 
 task killAllTestProcesses {
+    def Platform = "${System.properties['os.name'].toLowerCase()}" 
+    
     def ports = [6000, 8000]
- 
     ports.each { port ->
-        def cmd = "lsof -Fp -i :$port"
-        def process = cmd.execute()
-        process.in.eachLine { line ->
-        	def command = "kill -9 "+line.substring(1)
-        	def killProcess = command.execute()
-            killProcess.waitFor()
-        }
+     	if (Platform.contains('linux')){
+	        def cmd = "lsof -Fp -i :$port"
+	        def process = cmd.execute()
+	        process.in.eachLine { line ->
+	        	def command = "kill -9 "+line.substring(1)
+	        	def killProcess = command.execute()
+	            killProcess.waitFor()
+	        }
+	    }
+	    else if(Platform.contains('windows')) {
+	        def cmd = "netstat -a -o -n | findstr \"TCP\" | findstr \":$port\""
+	        def process = cmd.execute()
+	        process.in.eachLine { line ->
+	        	def command = "taskkill /F /PID  "+line.split('+ ')[4]
+	        	def killProcess = command.execute()
+	            killProcess.waitFor()
+	        }
+	    }
+
     }
 }
 
@@ -47,15 +65,20 @@ task killAllTestProcesses {
 task startDropServer(type: ExecWait) {
 	command 'python drop_server.py &'
 	ready 'Drop server running.'
-	directory './qabel-drop'
+	directory 'qabel-drop'
 	logname 'qabel-drop'
 }
 
 task getNodeModules(type: ExecWait) {
 	command 'npm install'
 	ready 'Storage server modules initialised.'
-	directory './qabel-storage'
+	directory 'qabel-storage'
 	logname 'npm'
+	waitfor true
+}
+
+task getNodeModule << {
+	
 }
 
 task checkStorage {
@@ -70,7 +93,7 @@ task checkStorage {
 }
 
 task startStorageServer(type: ExecWait) {
-	dependsOn checkStorage	
+	dependsOn 'checkStorage'	
 	command 'nodejs app.js &'
 	ready 'Storage server running.'
 	directory './qabel-storage'

--- a/build.gradle
+++ b/build.gradle
@@ -89,9 +89,21 @@ task checkStorage {
 	}
 }
 
-task startStorageServer(type: ExecWait) {
+task startStorageServerUnix(type: ExecWait) {
 	dependsOn 'checkStorage'
-	command 'nodejs app.js &'
+	def cmd = "./node.sh"
+	def process = cmd.execute()
+	process.in.eachLine { line ->
+		command line+' app.js &'
+	}
+	ready 'Storage server running.'
+	directory 'qabel-storage/'
+	logname 'qabel-storage'
+}
+
+task startStorageServerWindows(type: ExecWait) {
+	dependsOn 'checkStorage'
+	command 'node app.js &'
 	ready 'Storage server running.'
 	directory 'qabel-storage'
 	logname 'qabel-storage'
@@ -106,8 +118,15 @@ task startDropServer(type: ExecWait) {
 }
 
 task startServers {
+	def Platform = "${System.properties['os.name'].toLowerCase()}" 
+
 	startDropServer.execute()
-	startStorageServer.execute()
+	if (Platform.contains('windows')){
+		startStorageServerWindows.execute()
+	}
+	else {
+		startStorageServerUnix.execute()
+	}
 }
 
 gradle.addListener new TestLifecycleListener()

--- a/build.gradle
+++ b/build.gradle
@@ -61,50 +61,51 @@ task killAllTestProcesses {
     }
 }
 
-
-task startDropServer(type: ExecWait) {
-	command 'python drop_server.py &'
-	ready 'Drop server running.'
-	directory 'qabel-drop'
-	logname 'qabel-drop'
+task checkLogFolder {
+	File logFolder = new File("./log/")
+	if( !logFolder.exists() ) {
+		logFolder.mkdirs()
+	}
 }
 
 task getNodeModules(type: ExecWait) {
 	command 'npm install'
 	ready 'Storage server modules initialised.'
-	directory 'qabel-storage'
+	directory './qabel-storage'
 	logname 'npm'
 	waitfor true
 }
 
-task getNodeModule << {
-	
-}
-
 task checkStorage {
-	File dataFolder = new File("./qabel-storage/data/");
-	if( !dataFolder.exists() ) {
-		dataFolder.mkdirs();
+	dependsOn 'checkLogFolder'
+	File storagedataFolder = new File("./qabel-storage/data/")
+	if( !storagedataFolder.exists() ) {
+		storagedataFolder.mkdirs()
 	}
-	File nodeModulesFolder = new File("./qabel-storage/node_modules/");
+
+	File nodeModulesFolder = new File("./qabel-storage/node_modules/")
 	if( !nodeModulesFolder.exists() ) {
 		getNodeModules.execute()
 	}
 }
 
 task startStorageServer(type: ExecWait) {
-	dependsOn 'checkStorage'	
+	dependsOn 'checkStorage'
 	command 'nodejs app.js &'
 	ready 'Storage server running.'
-	directory './qabel-storage'
+	directory 'qabel-storage'
 	logname 'qabel-storage'
 }
 
+task startDropServer(type: ExecWait) {
+	dependsOn 'checkLogFolder'
+	command 'python drop_server.py &'
+	ready 'Drop server running.'
+	directory 'qabel-drop'
+	logname 'qabel-drop'
+}
+
 task startServers {
-	File logFolder = new File("./log/");
-	if( !logFolder.exists() ) {
-		logFolder.mkdirs();
-	}
 	startDropServer.execute()
 	startStorageServer.execute()
 }
@@ -116,6 +117,7 @@ class TestLifecycleListener implements TaskExecutionListener {
     @Override
     void beforeExecute(Task task) {
         if (task.name == 'test') {
+	        
               task.project.rootProject.startServers.execute();
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ class ExecWait extends DefaultTask {
 		ProcessBuilder builder = new ProcessBuilder(command.split(' '))
 		builder.redirectErrorStream(true)
 		builder.directory(new File(directory))
+		builder.redirectOutput(new File("./log/"+directory+".log"));
+
 		Process process = builder.start()
 
 		InputStream stdout = process.getInputStream()
@@ -26,16 +28,31 @@ class ExecWait extends DefaultTask {
 	}
 }
 
+task killAllTestProcesses {
+    def ports = [6000, 8000]
+ 
+    ports.each { port ->
+        def cmd = "lsof -Fp -i :$port"
+        def process = cmd.execute()
+        process.in.eachLine { line ->
+        	def command = "kill -9 "+line.substring(1)
+        	def killProcess = command.execute()
+            killProcess.waitFor()
+        }
+    }
+}
+
+
 task startDropServer(type: ExecWait) {
-	command './drop_server.py &'
+	command 'python drop_server.py &'
 	ready 'Drop server running.'
-	directory './qabel-drop/'
+	directory './qabel-drop'
 }
 
 task getNodeModules(type: ExecWait) {
 	command 'npm install'
 	ready 'Storage server modules initialised.'
-	directory './qabel-storage/'
+	directory './qabel-storage'
 }
 
 task checkStorage {
@@ -53,12 +70,44 @@ task startStorageServer(type: ExecWait) {
 	dependsOn checkStorage	
 	command 'nodejs app.js &'
 	ready 'Storage server running.'
-	directory './qabel-storage/'
+	directory './qabel-storage'
 }
 
-test {
-	dependsOn startDropServer, startStorageServer
+task startServers {
+	File logFolder = new File("./log/");
+	if( !logFolder.exists() ) {
+		logFolder.mkdirs();
+	}
+	startDropServer.execute()
+	startStorageServer.execute()
 }
+
+gradle.addListener new TestLifecycleListener()
+ 
+class TestLifecycleListener implements TaskExecutionListener {
+
+    @Override
+    void beforeExecute(Task task) {
+        if (task.name == 'test') {
+              task.project.rootProject.startServers.execute();
+        }
+    }
+ 
+    @Override
+    void afterExecute(Task task, TaskState taskState) {
+        if (task.name == 'test') {
+           task.project.rootProject.killAllTestProcesses.execute()
+        }
+    }
+}
+
+
+
+
+test {
+
+}
+
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ class ExecWait extends DefaultTask {
 	String command
 	String ready
 	String directory
+	String logname
 
 	@TaskAction
 	def spawnProcess() {
@@ -19,7 +20,7 @@ class ExecWait extends DefaultTask {
 		ProcessBuilder builder = new ProcessBuilder(command.split(' '))
 		builder.redirectErrorStream(true)
 		builder.directory(new File(directory))
-		builder.redirectOutput(new File("./log/"+directory+".log"));
+		builder.redirectOutput(new File("./log/"+logname+".log"));
 
 		Process process = builder.start()
 
@@ -47,12 +48,14 @@ task startDropServer(type: ExecWait) {
 	command 'python drop_server.py &'
 	ready 'Drop server running.'
 	directory './qabel-drop'
+	logname 'qabel-drop'
 }
 
 task getNodeModules(type: ExecWait) {
 	command 'npm install'
 	ready 'Storage server modules initialised.'
 	directory './qabel-storage'
+	logname 'npm'
 }
 
 task checkStorage {
@@ -71,6 +74,7 @@ task startStorageServer(type: ExecWait) {
 	command 'nodejs app.js &'
 	ready 'Storage server running.'
 	directory './qabel-storage'
+	logname 'qabel-storage'
 }
 
 task startServers {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ task checkStorage {
 
 task startStorageServer(type: ExecWait) {
 	dependsOn checkStorage	
-	command 'node app.js &'
+	command 'nodejs app.js &'
 	ready 'Storage server running.'
 	directory './qabel-storage/'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,6 @@ task startStorageServer(type: ExecWait) {
 	directory './qabel-storage/'
 }
 
-
-
 test {
 	dependsOn startDropServer, startStorageServer
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,12 @@ task startDropServer(type: ExecWait) {
 	directory './qabel-drop/'
 }
 
-task startDropStorage(type: ExecWait) {
+task startStorageServer(type: ExecWait) {
 	command 'node app.js &'
 	ready 'Storage server running.'
 	directory './qabel-storage/'
 }
 
 test {
-	dependsOn startDropServer, startDropStorage
+	dependsOn startDropServer, startStorageServer
 }

--- a/node.sh
+++ b/node.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+command -v nodejs || command -v node


### PR DESCRIPTION
Gradle will now automaticaly start a drop and storage server while running tests.
This pull request also includes a travis configuraation, and a updated README file.

Because the halloworld-module can't be built, the travis build will fail at the moment, but except for that everything is working.

This should resolve issue #7 
Also it seems, that this pull request also solves #6 