### PR TITLE
Run travis tests on the container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 sudo: false
 
-language: java
-
-jdk:
- - oraclejdk7
-
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ services:
   - redis-server
 
 install:
- - redis-server > /dev/null 2>&1 &
  - virtualenv qabel-drop
  - source qabel-drop/bin/activate
  - pip install -r qabel-drop/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
+sudo: false
+
 language: java
 
 jdk:
  - oraclejdk7
 
+language: python
+
+python:
+ - "2.7"
+
 notifications:
   email: false
 
+services:
+  - redis-server
+
 install:
  - redis-server > /dev/null 2>&1 &
- - sudo apt-get install python-pip npm nodejs
- - sudo pip install virtualenv
  - virtualenv qabel-drop
  - source qabel-drop/bin/activate
  - pip install -r qabel-drop/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ language: python
 python:
  - "2.7"
 
+cache: pip
+
 notifications:
   email: false
 


### PR DESCRIPTION
See #18 

This speeds up the tests massively but has the disadvantage  of not allowing multiple languages. We can not use python 3.4 and python 2.7, or oraclejdk8 and python3.4.

We can only specify one language at the moment, see https://github.com/travis-ci/travis-ci/issues/4090