### PR TITLE
Integrate qabel-accounting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "qabel-storage"]
 	path = qabel-storage
 	url = https://github.com/Qabel/qabel-storage.git
+[submodule "qabel-accounting"]
+	path = qabel-accounting
+	url = https://github.com/Qabel/qabel-accounting

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ services:
 
 install:
  - pip install -r qabel-drop/requirements.txt
+ - pip install -r qabel-accounting/requirements.txt
 
 script:
  - ./gradlew check

--- a/README.md
+++ b/README.md
@@ -16,10 +16,25 @@ Gradle superproject for all Qabel projects.
 
 0. npm
 
+0. python3.4
+
 0. python moduls from qabel-drop/requirements.txt
    ```
    this could for example automaticly be done using python-pip:
       pip install -r qabel-drop/requirements.txt
+   ```
+
+0. python modules from qabel-accounting/requirements.txt
+   ```
+   virtualenv --python=python3.4 qabel-accounting
+   source qabel-accounting/bin/activate
+   pip install -r qabel-drop/requirements.txt
+   ```
+
+0. migrations for qabel-accounting
+   ```
+   cd qabel-accounting
+   ./manage.py migrate
    ```
 
 0. lsof (Linux only)
@@ -62,5 +77,11 @@ Normaly the drop and storage server should be started automaticaly, but if you w
 
    windows
       node app.js
+   ```
+
+0. accounting-server
+   ```
+   cd qabel-accounting
+   bin/python3.4 manage.py runserver
    ```
    

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ qabel
 
 Gradle superproject for all Qabel projects.
 
+To use the accounting server, you need to configure an AWS account as shown in the
+[Boto 3 documentation](https://boto3.readthedocs.org/en/latest/guide/quickstart.html#configuration).
+
 ## requirements
 
 0. redis-server

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ task startDropServerWindows(type: ExecWait) {
 
 task startAccountingServerUnix(type: ExecWait) {
 	dependsOn 'checkLogFolder'
-	command 'python3.4 manage.py runserver 8080'
+	command 'python3.4 manage.py testserver testdata.json --addrport 9696'
 	ready 'Accounting server running.'
 	directory 'qabel-accounting'
 	logname 'qabel-accounting'
@@ -145,7 +145,7 @@ task startAccountingServerUnix(type: ExecWait) {
 
 task startAccountingServerWindows(type: ExecWait) {
 	dependsOn 'checkLogFolder'
-	command 'python3.4 manage.py runserver 8080'
+	command 'python3.4 manage.py testserver testdata.json --addrport 9696'
 	ready 'Accounting server running.'
 	directory 'qabel-accounting'
 	logname 'qabel-accounting'

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,21 @@ task startDropServerWindows(type: ExecWait) {
 	logname 'qabel-drop'
 }
 
+task startAccountingServerUnix(type: ExecWait) {
+	dependsOn 'checkLogFolder'
+	command 'python3.4 manage.py runserver 8080'
+	ready 'Accounting server running.'
+	directory 'qabel-accounting'
+	logname 'qabel-accounting'
+}
+
+task startAccountingServerWindows(type: ExecWait) {
+	dependsOn 'checkLogFolder'
+	command 'python3.4 manage.py runserver 8080'
+	ready 'Accounting server running.'
+	directory 'qabel-accounting'
+	logname 'qabel-accounting'
+}
 task startServers{
 	dependsOn 'checkLogFolder'
 	dependsOn 'checkStorage'
@@ -147,10 +162,12 @@ startServers << {
 	if (Platform.contains('windows')){
 		startDropServerWindows.execute()
 		startStorageServerWindows.execute()
+		startAccountingServerWindows.execute()
 	}
 	else {
 		startDropServerUnix.execute()
 		startStorageServerUnix.execute()
+		startAccountingServerUnix.execute()
 	}
 }
 


### PR DESCRIPTION
In preparation for the qabel-core API for the qabel-accounting server: https://github.com/Qabel/qabel-core/issues/385

The accounting server starts at port 9696 with predefined test fixtures.